### PR TITLE
Avoid "Image path must be absolute" error from Contao > 4.8.5

### DIFF
--- a/src/Notification/DefaultNotification.php
+++ b/src/Notification/DefaultNotification.php
@@ -124,7 +124,7 @@ class DefaultNotification extends AbstractNotification
                        
         $rootDir = System::getContainer()->getParameter('kernel.project_dir');
         $imageFactory = System::getContainer()->get('contao.image.image_factory');
-        if (($objModel = FilesModel::findByUuid($icon)) != null && is_file($rootDir . '/' . $objModel->path)) {
+        if ($objModel = FilesModel::findByUuid($icon) && is_file($rootDir . '/' . $objModel->path)) {
             $image = $imageFactory->create($rootDir . '/' . $objModel->path, $iconSize);
             $this->setIcon($image->getUrl($rootDir));
         }

--- a/src/Notification/DefaultNotification.php
+++ b/src/Notification/DefaultNotification.php
@@ -121,8 +121,12 @@ class DefaultNotification extends AbstractNotification
 		{
 			$iconSize = deserialize($iconSize);
 		}
-		$file = FilesModel::findByUuid($icon);
-		$image = System::getContainer()->get('contao.image.image_factory')->create($file->path, $iconSize);
-		$this->setIcon($image->getUrl(System::getContainer()->getParameter('kernel.project_dir')));
-	}
+                       
+        $rootDir = System::getContainer()->getParameter('kernel.project_dir');
+        $imageFactory = System::getContainer()->get('contao.image.image_factory');
+        if (($objModel = FilesModel::findByUuid($icon)) != null && is_file($rootDir . '/' . $objModel->path)) {
+            $image = $imageFactory->create($rootDir . '/' . $objModel->path, $iconSize);
+            $this->setIcon($image->getUrl($rootDir));
+        }
+    }
 }


### PR DESCRIPTION
Look at this issue: [Notification icon cause error: "mage path "%s" must be absolute"](https://github.com/heimrichhannot/contao-pwa-bundle/issues/9)